### PR TITLE
fix: 허용버튼을 누를 때만 알림로직이실행되는 버그

### DIFF
--- a/src/components/NotificationComponent.tsx
+++ b/src/components/NotificationComponent.tsx
@@ -24,23 +24,14 @@ export const NotificationComponent = () => {
   const queryClient = useQueryClient();
   const [isClient, setIsClient] = useState<boolean>(false);
   const PermitFCM = async () => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker
-        .register('/firebase-messaging-sw.js')
-        .then((registration) => {
-          console.log(
-            'Service Worker registered with scope:',
-            registration.scope
-          );
-        })
-        .catch((err) => {
-          console.error('Service Worker registration failed:', err);
-        });
-    }
+    
     // 브라우저에 알림 권한 요청
-    const permission = await Notification.requestPermission();
-    if (permission !== 'granted') return;
+    if (Notification.permission === 'default'&& !Cookies.get('deny_notification')) { 
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') return;
 
+    }
+    if (Notification.permission=== 'denied') return;
     const firebaseApp = initializeApp({
       apiKey: 'AIzaSyCguupCkfjsQ_8Bc0Je0o1aao80L4EzuUA',
       authDomain: 'amorgakco.firebaseapp.com',
@@ -80,6 +71,7 @@ export const NotificationComponent = () => {
       queryClient.invalidateQueries({
         predicate: (query) => query.queryKey[0] === 'notification',
       });
+      if(!Cookies.get('deny_notification')) {
       const notification = new Notification(
         payload.notification?.title ?? 'Default Title',
         {
@@ -90,6 +82,8 @@ export const NotificationComponent = () => {
       notification.onclick = () => {
         router.push('/notification');
       };
+    }
+
     });
   };
   const RefuseFCM = () => {
@@ -97,6 +91,24 @@ export const NotificationComponent = () => {
   };
   useEffect(() => {
     setIsClient(true);
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/firebase-messaging-sw.js')
+        .then((registration) => {
+          console.log(
+            'Service Worker registered with scope:',
+            registration.scope
+          );
+        })
+        .catch((err) => {
+          console.error('Service Worker registration failed:', err);
+        });
+    }
+    console.log('permitFCM')
+    if(Notification.permission !== 'default' || Cookies.get('deny_notification')) {
+      
+      PermitFCM();
+    }
   }, []);
 
   return (


### PR DESCRIPTION
## 🎀 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✨ 추가/수정 내용
- ios 대비하여 알림 허용여부 커스텀모달을 만드는과정에서 알림 등록 로직이 처음에 모달에서 허용버튼을 누를 때만 실행되는 버그 고침

## 🎊 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
